### PR TITLE
Update readme.md to reflect pkg-config on MacOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,14 @@ brew install sdl
 brew install pkg-config
 ```
 
-## Running:
+## Building:
 
 ```
 go build
 ```
 
+## Running:
+
+```
+./go-chip8 [ROM PATH]
+```

--- a/readme.md
+++ b/readme.md
@@ -2,17 +2,21 @@
 
 A Chip-8 VM because I needed something to write to learn go.
 
-Running:
+## Dependencies:
+* go >= 1.13
+* sdl
+* pkg-config
+
+### MacOS dependency installation
+```
+brew install go
+brew install sdl
+brew install pkg-config
+```
+
+## Running:
 
 ```
-Install SDL for your platform
-
-# on a mac:
-brew install sdl2{,_image,_mixer,_ttf,_gfx} pkg-config
-
-# And build it
 go build
-
-# And run it
-./go-chip8 [ROM PATH]
 ```
+


### PR DESCRIPTION
When building via `go build`, the SDL bindings require `pkg-config` to be present to find SDL dependencies. 